### PR TITLE
Fix peer dependency warning on React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prepublishOnly": "npm run -s build"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "@types/react": "16.9.19",


### PR DESCRIPTION
@faultyserver Thanks for the amazing focus lock. It is really great.

I just updated React’s peer dependency range since the latest React version is 17.0.1.