### PR TITLE
Re-add support for `returnRef`

### DIFF
--- a/examples/Dialog.tsx
+++ b/examples/Dialog.tsx
@@ -3,12 +3,13 @@ import useFocusLock from "../src/useFocusLock";
 
 type DialogProps = {
   children: React.ReactNode;
+  returnRef?: React.RefObject<HTMLElement>;
 };
 
 // Simple Dialog component that implements a focus lock with appropriate ARIA defaults.
-function Dialog({ children }: DialogProps) {
+function Dialog({ children, returnRef }: DialogProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
-  useFocusLock(containerRef);
+  useFocusLock(containerRef, { returnRef });
 
   return (
     <div

--- a/examples/ExplicitReturnExample.tsx
+++ b/examples/ExplicitReturnExample.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+import Dialog from "./Dialog";
+
+export default function ExplicitReturnExample() {
+  const [open, setOpen] = React.useState(false);
+
+  const returnRef = React.useRef<HTMLButtonElement>();
+
+  return (
+    <>
+      <h1>Returning Focus</h1>
+      <p>
+        This example shows how focus can be returned to a different element than the one that was
+        active when a layer was first activated. Note that if the provided target does not exist,
+        the return will default back to the last active element.
+      </p>
+      <button onClick={() => setOpen(true)}>This button opens the Dialog</button>
+      <button ref={returnRef}>But focus will be returned here</button>
+      {open && (
+        <Dialog returnRef={returnRef}>
+          <button onClick={() => setOpen(false)}>Close Dialog</button>
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/examples/SubscriptionExample.tsx
+++ b/examples/SubscriptionExample.tsx
@@ -5,7 +5,7 @@ import { useLockSubscription } from "../src/useFocusLock";
 import Dialog from "./Dialog";
 
 export default function CustomLockExample() {
-  const [enabled, setEnabled] = React.useState();
+  const [enabled, setEnabled] = React.useState(false);
   useLockSubscription(setEnabled);
 
   return (

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -4,6 +4,7 @@ import { render } from "react-dom";
 import { FocusGuard } from "../src/useFocusLock";
 
 import SimpleExample from "./SimpleExample";
+import ExplicitReturnExample from "./ExplicitReturnExample";
 import LayeringExample from "./LayeringExample";
 import FreeFocusToggleExample from "./FreeFocusToggleExample";
 import SubscriptionExample from "./SubscriptionExample";
@@ -21,6 +22,7 @@ function Index() {
       </p>
 
       <SimpleExample />
+      <ExplicitReturnExample />
       <LayeringExample />
       <FreeFocusToggleExample />
       <SubscriptionExample />


### PR DESCRIPTION
Fixes #7.

This re-adds the ability to specify a different target to return focus to when a lock layer is unmounted. If the ref does not resolve to an existing element on the page, the return will default back to whatever the previous `activeElement` was when the layer originally mounted.