### PR TITLE
Fix autoFocus when a lock layer is already active

### DIFF
--- a/examples/AutoFocusExample.tsx
+++ b/examples/AutoFocusExample.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+
+import Dialog from "./Dialog";
+
+export default function App() {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      <h1>Auto Focus</h1>
+      <p>
+        By default, the first tabbable element in a layer will receive focus. But if any element has
+        an `autoFocus` attribute, it will be respected and that element will receive focus instead
+        when the container mounts.
+      </p>
+      <button onClick={() => setOpen(true)}>Open Dialog</button>
+      {open && (
+        <Dialog>
+          <button>This would normally get focused</button>
+          <input type="text" placeholder="But this has autofocus!" autoFocus />
+          <button onClick={() => setOpen(false)}>Close Dialog</button>
+        </Dialog>
+      )}
+    </>
+  );
+}

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -4,6 +4,7 @@ import { render } from "react-dom";
 import { FocusGuard } from "../src/useFocusLock";
 
 import SimpleExample from "./SimpleExample";
+import AutoFocusExample from "./AutoFocusExample";
 import LayeringExample from "./LayeringExample";
 import FreeFocusToggleExample from "./FreeFocusToggleExample";
 import SubscriptionExample from "./SubscriptionExample";
@@ -21,6 +22,7 @@ function Index() {
       </p>
 
       <SimpleExample />
+      <AutoFocusExample />
       <LayeringExample />
       <FreeFocusToggleExample />
       <SubscriptionExample />

--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -95,17 +95,26 @@ export default function useFocusLock(
     }
 
     function handleFocusIn(event: FocusEvent) {
-      if (!enabledRef.current) return;
+      // This is scheduled for later to avoid problems when a new layer is being
+      // added on top of another. If the new layer has an `autoFocus` element, React
+      // will perform that focus before the previous layer's lock has been disabled,
+      // meaning focus will not be moved, and the new layer will just place focus on
+      // the first tabbable element, making the `autoFocus` appear broken. Waiting
+      // ensures that this layer will be disabled before attempting to intercept the
+      // autoFocus event.
+      requestAnimationFrame(() => {
+        if (!enabledRef.current) return;
 
-      const root = containerRef.current;
-      if (root == null) return;
+        const root = containerRef.current;
+        if (root == null) return;
 
-      const newFocusElement = (event.target as Element | null) || document.body;
-      if (root.contains(newFocusElement)) return;
+        const newFocusElement = (event.target as Element | null) || document.body;
+        if (root.contains(newFocusElement)) return;
 
-      event.preventDefault();
-      event.stopImmediatePropagation();
-      wrapFocus(root, newFocusElement);
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        wrapFocus(root, newFocusElement);
+      });
     }
 
     function handleFocusOut(event: FocusEvent) {


### PR DESCRIPTION
Fixes #12.

This changes the focus wrapping handlers to be scheduled for _after_ events have propagated and the `LOCK_STACK` has been updated with new layers. Waiting like this ensures that when new layer has an `autoFocus`ed element, it is not prevented from receiving focus by the previous layer's focus wrapping.