### PR TITLE
Fix CJS default imports

### DIFF
--- a/examples/Dialog.tsx
+++ b/examples/Dialog.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import useFocusLock from "../src/useFocusLock";
+import { useFocusLock } from "../src/useFocusLock";
 
 type DialogProps = {
   children: React.ReactNode;

--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -76,7 +76,7 @@ export type FocusLockOptions = {
   disable?: boolean;
 };
 
-export default function useFocusLock(
+export function useFocusLock(
   containerRef: React.RefObject<HTMLElement>,
   options: FocusLockOptions = {},
 ) {
@@ -158,6 +158,8 @@ export default function useFocusLock(
   // have been fully detached).
   useFocusReturn(returnRef, disableReturnRef);
 }
+
+export default useFocusLock;
 
 /**
  * A convenience component for rendering "guard elements" that ensure there is


### PR DESCRIPTION
Hopefully fixes #11.

This adds `useFocusLock` as a named export as well as the default export from `focus-layers` so that the whole package can be used with named exports only.