### PR TITLE
Try fixing autoFocus again, and remove all rAF usage

### DIFF
--- a/examples/AutoFocusExample.tsx
+++ b/examples/AutoFocusExample.tsx
@@ -4,6 +4,7 @@ import Dialog from "./Dialog";
 
 export default function App() {
   const [open, setOpen] = React.useState(false);
+  const [open2, setOpen2] = React.useState(false);
 
   return (
     <>
@@ -17,8 +18,17 @@ export default function App() {
       {open && (
         <Dialog>
           <button>This would normally get focused</button>
+          <button onClick={() => setOpen2(true)}>Open Dialog 2</button>
           <input type="text" placeholder="But this has autofocus!" autoFocus />
           <button onClick={() => setOpen(false)}>Close Dialog</button>
+        </Dialog>
+      )}
+
+      {open2 && (
+        <Dialog>
+          <button>This would normally get focused</button>
+          <input type="text" placeholder="But this has autofocus!" autoFocus />
+          <button onClick={() => setOpen2(false)}>Close Dialog</button>
         </Dialog>
       )}
     </>


### PR DESCRIPTION
This attempts to fix the problem with `autoFocus` by breaking out of React's Effect ordering and instead immediately disabling existing layers whenever a new layer is _about_ to be added (i.e., it runs inline with the component code, not in a callback to be run after the tree has been committed). Since `autoFocus` happens when the tree gets committed to the DOM, this should ensure that existing layers will not intercept that focus event.

The previous fix relying on rAF was really just eeking outside of a race condition between how long React takes to evaluate and commit the next DOM subtree and when the focus event propagates upward. This fix should be completely independent of that race.