### PR TITLE
Fix focus loosing for last page element

### DIFF
--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -118,7 +118,7 @@ export function useFocusLock(
 
       event.preventDefault();
       event.stopImmediatePropagation();
-      wrapFocus(root, newFocusElement);
+      wrapFocus(root, newFocusElement, true);
     }
 
     function handleFocusOut(event: FocusEvent) {
@@ -141,10 +141,10 @@ export function useFocusLock(
     const attachTo = attachToRef.current;
     if (attachTo == null) return;
 
-    attachTo.addEventListener("focusin", handleFocusIn as EventListener, { capture: true });
+    window.addEventListener("focusin", handleFocusIn as EventListener, { capture: true });
     attachTo.addEventListener("focusout", handleFocusOut as EventListener, { capture: true });
     return () => {
-      attachTo.removeEventListener("focusin", handleFocusIn as EventListener, { capture: true });
+      window.removeEventListener("focusin", handleFocusIn as EventListener, { capture: true });
       attachTo.removeEventListener("focusout", handleFocusOut as EventListener, { capture: true });
     };
   }, [containerRef, attachToRef]);


### PR DESCRIPTION
There is a bug.

If the focus is on the last element of the page, by pressing Tab button, focus moves to the address bar of the browser. After than you focus move to first focusable element of the page. Your hook tracks focus movement inside focus layer component. For this reason, focus trap stops working.

Also [this example](https://github.com/discord/focus-layers#basic-usage) currently not works too.