### PR TITLE
Refactor/move away from function hook args

### DIFF
--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -32,8 +32,12 @@ export function useFocusReturn(
   returnRef?: React.RefObject<HTMLElement>,
   disabledRef?: React.RefObject<boolean>,
 ) {
-  // This isn't necessarily safe, but realistically it's sufficient.
-  const [target] = React.useState(() => document.activeElement as HTMLElement);
+  const [target, setTarget] = React.useState<null | HTMLElement>(null);
+
+  React.useEffect(() => {
+    // This isn't necessarily safe, but realistically it's sufficient.
+    setTarget(document.activeElement as HTMLElement);
+  }, []);
 
   React.useLayoutEffect(() => {
     return () => {

--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -60,18 +60,20 @@ export function useFocusReturn(
  * layer, to be used for enabling/disabling the caller's lock logic.
  */
 export function useLockLayer(controlledUID?: string) {
-  const [uid] = React.useState(() => controlledUID || newLockUID());
-  const enabledRef = React.useRef(false);
-  // When first created, immediately disable the current layer (the one below
-  // this new one) to prevent its handlers from stealing focus back when this
-  // layer mounts. Specifically, this allows `autoFocus` to work, since React
-  // will perform the autofocus before any effects have run.
-  const [] = React.useState(() => LOCK_STACK.toggleLayer(LOCK_STACK.current(), false));
+  const enabledRef = React.useRef<boolean>(false);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
+    const uid = controlledUID || newLockUID();
+
+    // When first created, immediately disable the current layer (the one below
+    // this new one) to prevent its handlers from stealing focus back when this
+    // layer mounts. Specifically, this allows `autoFocus` to work, since React
+    // will perform the autofocus before any effects have run.
+    LOCK_STACK.toggleLayer(LOCK_STACK.current(), false);
+
     LOCK_STACK.add(uid, (enabled) => (enabledRef.current = enabled));
     return () => LOCK_STACK.remove(uid);
-  }, [uid]);
+  }, []);
 
   return enabledRef;
 }

--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -57,17 +57,17 @@ export function useFocusReturn(
  * layer, to be used for enabling/disabling the caller's lock logic.
  */
 export function useLockLayer(controlledUID?: string) {
+  const uidValue = controlledUID || newLockUID();
+  const [uid] = React.useState(uidValue);
   const enabledRef = React.useRef<boolean>(false);
 
+  // When first created, immediately disable the current layer (the one below
+  // this new one) to prevent its handlers from stealing focus back when this
+  // layer mounts. Specifically, this allows `autoFocus` to work, since React
+  // will perform the autofocus before any effects have run.
+  LOCK_STACK.toggleLayer(LOCK_STACK.current(), false);
+
   React.useEffect(() => {
-    const uid = controlledUID || newLockUID();
-
-    // When first created, immediately disable the current layer (the one below
-    // this new one) to prevent its handlers from stealing focus back when this
-    // layer mounts. Specifically, this allows `autoFocus` to work, since React
-    // will perform the autofocus before any effects have run.
-    LOCK_STACK.toggleLayer(LOCK_STACK.current(), false);
-
     LOCK_STACK.add(uid, (enabled) => (enabledRef.current = enabled));
     return () => LOCK_STACK.remove(uid);
   }, []);

--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -32,12 +32,9 @@ export function useFocusReturn(
   returnRef?: React.RefObject<HTMLElement>,
   disabledRef?: React.RefObject<boolean>,
 ) {
-  const [target, setTarget] = React.useState<null | HTMLElement>(null);
-
-  React.useEffect(() => {
-    // This isn't necessarily safe, but realistically it's sufficient.
-    setTarget(document.activeElement as HTMLElement);
-  }, []);
+  // This isn't necessarily safe, but realistically it's sufficient.
+  const activeElement = document.activeElement as HTMLElement;
+  const [target] = React.useState<null | HTMLElement>(activeElement);
 
   React.useLayoutEffect(() => {
     return () => {


### PR DESCRIPTION
## What
I updated the usage of `React.useState` to no longer use anonymous functions within the initial declaration. This is something that should be done, as this is generally regarded as bad practice as far as I'm aware. Would be happy to hear other opinions or thoughts. 

## Testing
I have tested all examples within the `/examples` dir to verify that everything still works as expected.

## Additional thoughts
We should add some unit tests to the library to enable better stability


Also, thank you so much for creating this library, and making it public. It is hugely appreciated and helpful to us.