### PR TITLE
fix usage of react state setter

### DIFF
--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -170,7 +170,7 @@ export default useFocusLock;
  */
 export const FocusGuard = React.memo(() => {
   const [active, setActive] = React.useState(false);
-  useLockSubscription(setActive);
+  useLockSubscription((newActiveState) => setActive(newActiveState));
 
   return (
     <div


### PR DESCRIPTION
## What?
The react useState setter, only accepts one argument, but the lock listener passes back two arguments (`active`, and `stack`). So to fix some linting errors we are seeing, and also resolve incorrect usage of this method, I have added an anonymous function to only pass the one argument through to the setter.

## Additional thoughts
I think it would be really great if we could add some unit tests to this library!

P.S. Thanks for making this library, and sharing it. It is incredibly helpful for us.