### PR TITLE
Fix alt-tab focusing

### DIFF
--- a/src/useFocusLock.tsx
+++ b/src/useFocusLock.tsx
@@ -127,7 +127,8 @@ export function useFocusLock(
       const root = containerRef.current;
       if (root == null) return;
 
-      const newFocusElement = (event.relatedTarget as Element | null) || document.body;
+      const newFocusElement =
+        (event.relatedTarget as Element | null) || document.activeElement || document.body;
       if (event.relatedTarget === document.body) {
         event.preventDefault();
         root.focus();


### PR DESCRIPTION
**Repro:**
- Run examples
- Open dialog, focus the text input
- Alt tab browser / change window focus
- Return window focus

**Expected:**
- Text input remains focused after returning

**Actual:**
- Some button is focused instead

I'm not sure if this would have negative side effects but it appears to resolve the issue. `relatedTarget` is null on window defocus events, but the `activeElement` appears to still be set to the expected element.